### PR TITLE
[fix] #5 - Refactor fetchNote to use headers for dynamic URL construction

### DIFF
--- a/app/shared/[token]/page.tsx
+++ b/app/shared/[token]/page.tsx
@@ -1,13 +1,17 @@
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { headers } from "next/headers";
 import type { Metadata } from "next";
 
 interface Props { params: Promise<{ token: string }> }
 
 async function fetchNote(token: string) {
-  const base = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
-  const res = await fetch(`${base}/api/notes/shared/${token}`, { cache: "no-store" });
+  const h = headers();
+  const host = (await h).get("host");
+  const protocol = host?.startsWith("localhost") ? "http" : "https";
+  const url = `${protocol}://${host}/api/notes/shared/${token}`;
+  const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) return null;
   const json = await res.json();
   return json.note ?? null;


### PR DESCRIPTION
## Summary

 Refactored fetchNote in sharedNote to use headers for dynamic URL construction instead of an env variable.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] 🎨 Style / UI
- [ ] ♻️ Refactor
- [ ] 🔧 Chore / tooling

## Changes

fetchNote inside shared note.
Using the host header to determine the URL for fetching the note.

## Testing

- [x] Tested locally with `npm run dev`
- [x] `npm run build` passes
- [x] `npm run lint` passes
## Related issues

Closes #5 
