### PR TITLE
[fix] Fixed #10 - users with special username wasnt able to log in

### DIFF
--- a/app/api/lib/auth.ts
+++ b/app/api/lib/auth.ts
@@ -71,18 +71,8 @@ export async function authUserWithUsername(
       return false;
     }
 
-    const headerRes = await axios.get(
-      `https://sms.schoolsoft.se/${school}/rest-api/student/header/student`,
-      { responseType: "json", headers: baseHeaders, validateStatus: () => true }
-    );
-
-    if (headerRes.status !== 200 || !headerRes.data) {
-      console.warn(`[authUserWithUsername] Student header fetch failed: ${headerRes.status}`);
-      return false;
-    }
-
     const fetchedUsername =
-      `${headerRes.data.firstName}.${headerRes.data.lastName}`.toLowerCase();
+      `${sessionRes.data.user.userName}`.toLowerCase();
 
     if (fetchedUsername !== expectedUsername) {
       console.warn(


### PR DESCRIPTION
Simplify username fetching in authUserWithUsername by removing redundant student header fetch and use the session to determine the username. #10

## Summary

Before, we used the header API from schoolsoft to add the first name and last name together and determine the username. But people with special names, like two first names, couldn't get authenticated with this. Now using the username in session which we already fetched before but didn't realize we could use that.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] 🎨 Style / UI
- [ ] ♻️ Refactor
- [ ] 🔧 Chore / tooling
## Testing

- [x] Tested locally with `npm run dev`
- [x] `npm run build` passes
- [x] `npm run lint` passes

## Related issues

Closes #10 
